### PR TITLE
fix(ci): use pnpm publish to resolve workspace: protocol

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,6 +2,13 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      publish_only:
+        description: 'Skip release-please and only publish packages'
+        required: false
+        default: 'false'
+        type: boolean
 
 permissions:
   contents: write
@@ -12,6 +19,7 @@ name: release-please
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' || inputs.publish_only != true }}
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       core_released: ${{ steps.release.outputs['packages/core--release_created'] }}
@@ -31,7 +39,7 @@ jobs:
 
   publish:
     needs: release-please
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    if: ${{ always() && (needs.release-please.outputs.releases_created == 'true' || inputs.publish_only == true) }}
     runs-on: ubuntu-latest
     environment: npm
     permissions:
@@ -49,7 +57,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
@@ -59,12 +67,13 @@ jobs:
       - name: Build packages
         run: pnpm build
 
+      # IMPORTANT: Use pnpm publish (not npm publish) to resolve workspace: protocols
+      # pnpm automatically converts workspace:* to actual version numbers during publish
+      # See: https://pnpm.io/cli/publish and https://github.com/pnpm/pnpm/issues/9812
       - name: Publish core package to npm
-        if: ${{ needs.release-please.outputs.core_released == 'true' }}
-        working-directory: packages/core
-        run: npm publish --provenance --access public
+        if: ${{ needs.release-please.outputs.core_released == 'true' || inputs.publish_only == true }}
+        run: pnpm --filter @pleaseai/context-please-core publish --access public --no-git-checks
 
       - name: Publish mcp package to npm
-        if: ${{ needs.release-please.outputs.mcp_released == 'true' }}
-        working-directory: packages/mcp
-        run: npm publish --provenance --access public
+        if: ${{ needs.release-please.outputs.mcp_released == 'true' || inputs.publish_only == true }}
+        run: pnpm --filter @pleaseai/context-please-mcp publish --access public --no-git-checks


### PR DESCRIPTION
## Summary

Fixes the npm installation error `Unsupported URL Type "workspace:": workspace:*` that occurs when users try to install `@pleaseai/context-please-mcp` via npm/npx.

### Root Cause
The previous workflow used `npm publish` directly from package directories, which doesn't understand pnpm's `workspace:` protocol. This caused version 0.4.1 to be published with unresolved `workspace:*` dependencies.

### Changes
- Use `pnpm --filter` to publish packages (properly resolves `workspace:` protocol)
- Add `workflow_dispatch` for manual publish triggering
- Update to Node.js 24.x
- Add documentation comments explaining why pnpm publish is required

### Verification

| Version | Core Dependency | Status |
|---------|----------------|--------|
| 0.3.0 | `0.3.0` | ✅ Correct |
| 0.4.0 | `0.5.0` | ✅ Correct |
| 0.4.1 | `workspace:*` | ❌ Broken (this PR fixes future releases) |

### After Merge
After merging this PR, trigger a new release via release-please to publish a fixed version.

## Test Plan
- [ ] Workflow syntax is valid (GitHub Actions validates on push)
- [ ] After merge, trigger release-please to create a new release
- [ ] Verify new published version has resolved dependencies

## References
- https://pnpm.io/cli/publish
- https://github.com/pnpm/pnpm/issues/9812
- https://docs.npmjs.com/trusted-publishers/

Fixes #59