### PR TITLE
fix: prevent search_code and index_codebase from crashing MCP process

### DIFF
--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -17,6 +17,45 @@ export class ToolHandlers {
     console.log(`[WORKSPACE] Current workspace: ${this.currentWorkspace}`)
   }
 
+  /** Timeout (ms) for the non-blocking cloud sync. */
+  private static readonly CLOUD_SYNC_TIMEOUT_MS = 10_000
+
+  /** Whether a non-blocking cloud sync is already in flight. */
+  private cloudSyncInFlight = false
+
+  /**
+   * Fire-and-forget cloud sync with a timeout guard.
+   *
+   * - Never blocks the calling handler.
+   * - Prevents overlapping syncs (single-flight).
+   * - Aborts after CLOUD_SYNC_TIMEOUT_MS so a hung ensureLoaded() call on a
+   *   remote Milvus instance cannot crash the MCP process.
+   */
+  private nonBlockingCloudSync(): void {
+    if (this.cloudSyncInFlight) {
+      return
+    }
+
+    this.cloudSyncInFlight = true
+
+    let timeoutId: NodeJS.Timeout
+    const timeout = new Promise<void>((_, reject) => {
+      timeoutId = setTimeout(
+        () => reject(new Error('Cloud sync timed out')),
+        ToolHandlers.CLOUD_SYNC_TIMEOUT_MS,
+      )
+    })
+
+    Promise.race([this.syncIndexedCodebasesFromCloud(), timeout])
+      .catch((err) => {
+        console.warn(`[SYNC-CLOUD] Non-blocking cloud sync failed: ${err.message || err}`)
+      })
+      .finally(() => {
+        clearTimeout(timeoutId)
+        this.cloudSyncInFlight = false
+      })
+  }
+
   /**
    * Sync indexed codebases from vector database collections
    * This method fetches all collections from the vector database (Milvus, Zilliz, or Qdrant),
@@ -170,8 +209,11 @@ export class ToolHandlers {
     const customIgnorePatterns = ignorePatterns || []
 
     try {
-      // Sync indexed codebases from cloud first
-      await this.syncIndexedCodebasesFromCloud()
+      // Cloud sync runs on startup via SyncManager.startBackgroundSync().
+      // Calling it here blocks every index request and can crash the MCP
+      // process when ensureLoaded() hangs on a remote/shared Milvus instance.
+      // Fire-and-forget with a timeout so it never blocks or kills the process.
+      this.nonBlockingCloudSync()
 
       // Validate splitter parameter
       if (splitterType !== 'ast' && splitterType !== 'langchain') {
@@ -454,8 +496,11 @@ export class ToolHandlers {
     const resultLimit = limit || 10
 
     try {
-      // Sync indexed codebases from cloud first
-      await this.syncIndexedCodebasesFromCloud()
+      // Cloud sync runs on startup via SyncManager.startBackgroundSync().
+      // Calling it here blocks every search request and can crash the MCP
+      // process when ensureLoaded() hangs on a remote/shared Milvus instance.
+      // Fire-and-forget with a timeout so it never blocks or kills the process.
+      this.nonBlockingCloudSync()
 
       // Force absolute path resolution - warn if relative path provided
       const absolutePath = ensureAbsolutePath(codebasePath)


### PR DESCRIPTION
> **Disclosure:** This PR was generated with assistance from Claude Code (Anthropic). My TypeScript knowledge is limited — thorough review is appreciated.

## Summary

- Replaces blocking `await this.syncIndexedCodebasesFromCloud()` in `handleSearchCode` and `handleIndexCodebase` with a non-blocking fire-and-forget wrapper
- Adds a 10-second timeout guard so a hung `ensureLoaded()` call on a remote Milvus instance cannot kill the MCP process
- Adds single-flight protection to prevent overlapping sync operations

Fixes #71

## Problem

`search_code` and `index_codebase` both `await` `syncIndexedCodebasesFromCloud()` before processing the request. This method iterates **all** collections in the vector database and calls `ensureLoaded()` on each one. On a remote or shared Milvus/Zilliz instance, `ensureLoaded()` can hang indefinitely (the gRPC client has no default timeout), which blocks the handler, causes the stdio transport to drop, and crashes the MCP process with `socket hang up`.

`get_indexing_status` and `clear_index` do **not** call this method and work correctly — confirming the sync call is the crash point.

This is also redundant work — `SyncManager.startBackgroundSync()` already performs cloud sync on MCP server startup.

## Changes

**`packages/mcp/src/handlers.ts`**

1. Added `nonBlockingCloudSync()` method:
   - Fire-and-forget (does not return a Promise to the caller)
   - `Promise.race` with a 10-second timeout — if sync doesn't complete in time, it's abandoned gracefully
   - Single-flight flag (`cloudSyncInFlight`) prevents overlapping syncs
   - Errors are caught and logged as warnings, never propagated to the handler

2. Replaced both `await this.syncIndexedCodebasesFromCloud()` calls with `this.nonBlockingCloudSync()`

## Test plan

- [ ] Configure with a remote Milvus instance (`MILVUS_ADDRESS=x.x.x.x:19530`)
- [ ] Call `search_code` — should return results or "not indexed" message without crashing
- [ ] Call `index_codebase` — should start indexing without crashing
- [ ] Verify startup sync via `SyncManager` still runs on process start
- [ ] Verify that rapid successive `search_code` calls don't trigger overlapping syncs

🤖 Generated with [Claude Code](https://claude.com/claude-code)